### PR TITLE
chore: update dependencies

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
       "jsr:@std/fmt@^1.0.1": "jsr:@std/fmt@1.0.1",
       "jsr:@std/fs@^1.0.2": "jsr:@std/fs@1.0.2",
       "jsr:@std/internal@^1.0.2": "jsr:@std/internal@1.0.2",
+      "jsr:@std/internal@^1.0.6": "jsr:@std/internal@1.0.8",
       "jsr:@std/io@^0.224.6": "jsr:@std/io@0.224.6",
       "jsr:@std/log@^0.224.5": "jsr:@std/log@0.224.6",
       "jsr:@std/testing@^1.0.1": "jsr:@std/testing@1.0.1",
@@ -29,6 +30,12 @@
           "npm:@types/sinonjs__fake-timers@^8.1.5"
         ]
       },
+      "@std/assert@1.0.13": {
+        "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+        "dependencies": [
+          "jsr:@std/internal@^1.0.6"
+        ]
+      },
       "@std/assert@1.0.3": {
         "integrity": "b0d03ce1ced880df67132eea140623010d415848df66f6aa5df76507ca7c26d8",
         "dependencies": [
@@ -46,6 +53,9 @@
       },
       "@std/internal@1.0.2": {
         "integrity": "f4cabe2021352e8bfc24e6569700df87bf070914fc38d4b23eddd20108ac4495"
+      },
+      "@std/internal@1.0.8": {
+        "integrity": "fc66e846d8d38a47cffd274d80d2ca3f0de71040f855783724bb6b87f60891f5"
       },
       "@std/io@0.224.6": {
         "integrity": "eefe034a370be34daf066c8634dd645635d099bb21eccf110f0bdc28d9040891"

--- a/deno.lock
+++ b/deno.lock
@@ -6,7 +6,7 @@
       "jsr:@milly/streamtest@^1.0.1": "jsr:@milly/streamtest@1.0.2",
       "jsr:@std/assert@^1.0.1": "jsr:@std/assert@1.0.3",
       "jsr:@std/assert@^1.0.3": "jsr:@std/assert@1.0.3",
-      "jsr:@std/async@^1.0.1": "jsr:@std/async@1.0.4",
+      "jsr:@std/async@^1.0.1": "jsr:@std/async@1.0.13",
       "jsr:@std/fmt@^1.0.1": "jsr:@std/fmt@1.0.1",
       "jsr:@std/fs@^1.0.2": "jsr:@std/fs@1.0.2",
       "jsr:@std/internal@^1.0.2": "jsr:@std/internal@1.0.2",
@@ -42,8 +42,8 @@
           "jsr:@std/internal@^1.0.2"
         ]
       },
-      "@std/async@1.0.4": {
-        "integrity": "373f5168a01b46ecaabc785d4e0f9ef18a010ab867af069fb905d93a9129ae5b"
+      "@std/async@1.0.13": {
+        "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
       },
       "@std/fmt@1.0.1": {
         "integrity": "ef76c37faa7720faa8c20fd8cc74583f9b1e356dfd630c8714baa716a45856ab"

--- a/deno.lock
+++ b/deno.lock
@@ -4,16 +4,23 @@
     "specifiers": {
       "jsr:@core/asyncutil@^1.1.1": "jsr:@core/asyncutil@1.2.0",
       "jsr:@milly/streamtest@^1.0.1": "jsr:@milly/streamtest@1.0.2",
-      "jsr:@std/assert@^1.0.1": "jsr:@std/assert@1.0.3",
+      "jsr:@std/assert@^1.0.1": "jsr:@std/assert@1.0.13",
+      "jsr:@std/assert@^1.0.13": "jsr:@std/assert@1.0.13",
       "jsr:@std/assert@^1.0.3": "jsr:@std/assert@1.0.3",
       "jsr:@std/async@^1.0.1": "jsr:@std/async@1.0.13",
+      "jsr:@std/async@^1.0.13": "jsr:@std/async@1.0.13",
+      "jsr:@std/data-structures@^1.0.8": "jsr:@std/data-structures@1.0.8",
       "jsr:@std/fmt@^1.0.1": "jsr:@std/fmt@1.0.1",
+      "jsr:@std/fs@^1.0.17": "jsr:@std/fs@1.0.17",
       "jsr:@std/fs@^1.0.2": "jsr:@std/fs@1.0.2",
       "jsr:@std/internal@^1.0.2": "jsr:@std/internal@1.0.2",
       "jsr:@std/internal@^1.0.6": "jsr:@std/internal@1.0.8",
+      "jsr:@std/internal@^1.0.8": "jsr:@std/internal@1.0.8",
       "jsr:@std/io@^0.224.6": "jsr:@std/io@0.224.6",
       "jsr:@std/log@^0.224.5": "jsr:@std/log@0.224.6",
-      "jsr:@std/testing@^1.0.1": "jsr:@std/testing@1.0.1",
+      "jsr:@std/path@^1.0.9": "jsr:@std/path@1.1.0",
+      "jsr:@std/path@^1.1.0": "jsr:@std/path@1.1.0",
+      "jsr:@std/testing@^1.0.1": "jsr:@std/testing@1.0.13",
       "npm:@sinonjs/fake-timers@^13.0.1": "npm:@sinonjs/fake-timers@13.0.1",
       "npm:@types/sinonjs__fake-timers@^8.1.5": "npm:@types/sinonjs__fake-timers@8.1.5"
     },
@@ -45,8 +52,17 @@
       "@std/async@1.0.13": {
         "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
       },
+      "@std/data-structures@1.0.8": {
+        "integrity": "2fb7219247e044c8fcd51341788547575653c82ae2c759ff209e0263ba7d9b66"
+      },
       "@std/fmt@1.0.1": {
         "integrity": "ef76c37faa7720faa8c20fd8cc74583f9b1e356dfd630c8714baa716a45856ab"
+      },
+      "@std/fs@1.0.17": {
+        "integrity": "1c00c632677c1158988ef7a004cb16137f870aafdb8163b9dce86ec652f3952b",
+        "dependencies": [
+          "jsr:@std/path@^1.0.9"
+        ]
       },
       "@std/fs@1.0.2": {
         "integrity": "af57555c7a224a6f147d5cced5404692974f7a628ced8eda67e0d22d92d474ec"
@@ -68,10 +84,18 @@
           "jsr:@std/io@^0.224.6"
         ]
       },
-      "@std/testing@1.0.1": {
-        "integrity": "9c25841137ee818933e1722091bb9ed5fdc251c35e84c97979a52196bdb6c5c3",
+      "@std/path@1.1.0": {
+        "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
+      },
+      "@std/testing@1.0.13": {
+        "integrity": "74418be16f627dfe996937ab0ffbdbda9c1f35534b78724658d981492f121e71",
         "dependencies": [
-          "jsr:@std/assert@^1.0.3"
+          "jsr:@std/assert@^1.0.13",
+          "jsr:@std/async@^1.0.13",
+          "jsr:@std/data-structures@^1.0.8",
+          "jsr:@std/fs@^1.0.17",
+          "jsr:@std/internal@^1.0.8",
+          "jsr:@std/path@^1.1.0"
         ]
       }
     },

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,7 @@
   "version": "3",
   "packages": {
     "specifiers": {
-      "jsr:@core/asyncutil@^1.1.1": "jsr:@core/asyncutil@1.1.1",
+      "jsr:@core/asyncutil@^1.1.1": "jsr:@core/asyncutil@1.2.0",
       "jsr:@milly/streamtest@^1.0.1": "jsr:@milly/streamtest@1.0.2",
       "jsr:@std/assert@^1.0.1": "jsr:@std/assert@1.0.3",
       "jsr:@std/assert@^1.0.3": "jsr:@std/assert@1.0.3",
@@ -17,8 +17,8 @@
       "npm:@types/sinonjs__fake-timers@^8.1.5": "npm:@types/sinonjs__fake-timers@8.1.5"
     },
     "jsr": {
-      "@core/asyncutil@1.1.1": {
-        "integrity": "64540c79e023605f1c3cee2a50291d4d83d495b89a2b32c99fd3c2fbf445971c"
+      "@core/asyncutil@1.2.0": {
+        "integrity": "9967f15190c60df032c13f72ce5ac73d185c34f31c53dc918d8800025854c118"
       },
       "@milly/streamtest@1.0.2": {
         "integrity": "76b3cf170af04c8cc58f80cf523077cc268a2f64640a4f88c102461084393540",
@@ -96,19 +96,6 @@
       "jsr:@std/assert@^1.0.1",
       "jsr:@std/async@^1.0.1",
       "jsr:@std/testing@^1.0.1"
-    ],
-    "packageJson": {
-      "dependencies": [
-        "npm:@jsr/core__asyncutil@^1.1.1",
-        "npm:@jsr/milly__streamtest@^1.0.1",
-        "npm:@jsr/std__assert@^1.0.1",
-        "npm:@jsr/std__async@^1.0.1",
-        "npm:@jsr/std__testing@^1.0.1",
-        "npm:@playwright/test@^1.44.1",
-        "npm:esbuild@^0.21.4",
-        "npm:glob@^10.4.1",
-        "npm:tsx@^4.12.0"
-      ]
-    }
+    ]
   }
 }


### PR DESCRIPTION
#### :package: @core/asyncutil [1.1.1](https://jsr.io/@core/asyncutil/1.1.1) → [1.2.0](https://jsr.io/@core/asyncutil/1.2.0)

- feat: add `waiterCount` to reveal the number of lock waiters

#### :package: @std/assert [1.0.3](https://jsr.io/@std/assert/1.0.3) → [1.0.13](https://jsr.io/@std/assert/1.0.13)

#### :package: @std/async [1.0.4](https://jsr.io/@std/async/1.0.4) → [1.0.13](https://jsr.io/@std/async/1.0.13)

#### :package: @std/testing [1.0.1](https://jsr.io/@std/testing/1.0.1) → [1.0.13](https://jsr.io/@std/testing/1.0.13)