### PR TITLE
feat: throws if callback is invalid

### DIFF
--- a/readable/defer.ts
+++ b/readable/defer.ts
@@ -35,7 +35,7 @@ export function defer<T>(
   inputFactory: () => StreamSource<T>,
 ): ReadableStream<T> {
   if (typeof inputFactory !== "function") {
-    throw new TypeError("No inputFactory function found");
+    throw new TypeError("'inputFactory' is not a function");
   }
 
   let reader: ReadableStreamDefaultReader<T> | undefined;

--- a/readable/defer_test.ts
+++ b/readable/defer_test.ts
@@ -78,6 +78,7 @@ describe("defer()", () => {
         assertThrows(
           () => defer(inputFactory),
           TypeError,
+          "'inputFactory' is not a function",
         );
       });
     }

--- a/readable/defer_test.ts
+++ b/readable/defer_test.ts
@@ -70,6 +70,7 @@ describe("defer()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => [])],
       ["ArrayLike", { length: 2, "0": "a", "1": "b" }],
     ];
     for (const [name, inputFactory] of tests) {

--- a/readable/from_event.ts
+++ b/readable/from_event.ts
@@ -123,6 +123,9 @@ export function fromEvent<E, R>(
     ? { predicate: optionsOrPredicate }
     : optionsOrPredicate;
   const { once, signal, capture, predicate } = options ?? {};
+  if (predicate !== undefined && typeof predicate !== "function") {
+    throw new TypeError("'predicate' is not a function");
+  }
   let index = 0;
   let teardown: () => void;
   return new ReadableStream({

--- a/readable/from_message.ts
+++ b/readable/from_message.ts
@@ -110,7 +110,7 @@ export function fromMessage<T, R>(
     : optionsOrPredicate;
   const { force, predicate } = options ?? {};
   if (target.onmessage != null && !force) {
-    throw new TypeError("target.onmessage is not empty");
+    throw new TypeError("'target.onmessage' is not empty");
   }
   if (predicate !== undefined && typeof predicate !== "function") {
     throw new TypeError("'predicate' is not a function");

--- a/readable/from_message.ts
+++ b/readable/from_message.ts
@@ -112,6 +112,9 @@ export function fromMessage<T, R>(
   if (target.onmessage != null && !force) {
     throw new TypeError("target.onmessage is not empty");
   }
+  if (predicate !== undefined && typeof predicate !== "function") {
+    throw new TypeError("'predicate' is not a function");
+  }
   let index = 0;
   return new ReadableStream({
     start(controller) {

--- a/readable/from_message_test.ts
+++ b/readable/from_message_test.ts
@@ -61,14 +61,14 @@ describe("fromMessage()", () => {
       assertThrows(
         () => fromMessage(target),
         TypeError,
-        "target.onmessage is not empty",
+        "'target.onmessage' is not empty",
       );
     });
     it("throws if `force` is false", () => {
       assertThrows(
         () => fromMessage(target, { force: false }),
         TypeError,
-        "target.onmessage is not empty",
+        "'target.onmessage' is not empty",
       );
     });
     it("does not throws if `force` is true", () => {

--- a/readable/from_message_test.ts
+++ b/readable/from_message_test.ts
@@ -75,6 +75,30 @@ describe("fromMessage()", () => {
       fromMessage(target, { force: true });
     });
   });
+  describe("throws if `options.predicate` is", () => {
+    // deno-lint-ignore no-explicit-any
+    const tests: [name: string, predicate: any][] = [
+      ["null", null],
+      ["string", "foo"],
+      ["number", 42],
+      ["object", { foo: 42 }],
+      ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => true)],
+    ];
+    for (const [name, predicate] of tests) {
+      it(name, () => {
+        const target: FromMessageTarget<string> = {
+          onmessage: null,
+        };
+
+        assertThrows(
+          () => fromMessage(target, { predicate }),
+          TypeError,
+          "'predicate' is not a function",
+        );
+      });
+    }
+  });
   describe("returns a ReadableStream and", () => {
     it("set or delete the message handler to the `target`", async () => {
       const target = { onmessage: null };

--- a/transform/concat_map_test.ts
+++ b/transform/concat_map_test.ts
@@ -79,6 +79,7 @@ describe("concatMap()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => [])],
     ];
     for (const [name, project] of tests) {
       it(name, () => {

--- a/transform/default_with.ts
+++ b/transform/default_with.ts
@@ -31,7 +31,7 @@ export function defaultWith<I, D = I>(
   defaultFactory: () => StreamSource<D>,
 ): TransformStream<I, I | D> {
   if (typeof defaultFactory !== "function") {
-    throw new TypeError("No defaultFactory function found");
+    throw new TypeError("'defaultFactory' is not a function");
   }
 
   let hasChunk = false;

--- a/transform/default_with_test.ts
+++ b/transform/default_with_test.ts
@@ -24,6 +24,7 @@ describe("defaultWith()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => [])],
     ];
     for (const [name, defaultFactory] of tests) {
       it(name, () => {

--- a/transform/default_with_test.ts
+++ b/transform/default_with_test.ts
@@ -31,6 +31,7 @@ describe("defaultWith()", () => {
         assertThrows(
           () => defaultWith(defaultFactory),
           TypeError,
+          "'defaultFactory' is not a function",
         );
       });
     }

--- a/transform/every.ts
+++ b/transform/every.ts
@@ -28,6 +28,9 @@
 export function every<T>(
   predicate: (value: T, index: number) => boolean,
 ): TransformStream<T, boolean> {
+  if (typeof predicate !== "function") {
+    throw new TypeError("'predicate' is not a function");
+  }
   let index = -1;
   let closed = false;
   return new TransformStream({

--- a/transform/every_test.ts
+++ b/transform/every_test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "#bdd";
-import { assertInstanceOf } from "@std/assert";
+import { assertInstanceOf, assertThrows } from "@std/assert";
 import { assertEquals } from "@std/assert";
 import { assertType, type IsExact } from "@std/testing/types";
 import { spy } from "@std/testing/mock";
@@ -14,6 +14,27 @@ describe("every()", () => {
     assertType<IsExact<typeof actual, TransformStream<unknown, boolean>>>(true);
     assertInstanceOf(actual.readable, ReadableStream);
     assertInstanceOf(actual.writable, WritableStream);
+  });
+  describe("throws if `predicate` is", () => {
+    // deno-lint-ignore no-explicit-any
+    const tests: [name: string, predicate: any][] = [
+      ["null", null],
+      ["undefined", undefined],
+      ["string", "foo"],
+      ["number", 42],
+      ["object", { foo: 42 }],
+      ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => true)],
+    ];
+    for (const [name, predicate] of tests) {
+      it(name, () => {
+        assertThrows(
+          () => every(predicate),
+          TypeError,
+          "'predicate' is not a function",
+        );
+      });
+    }
   });
   describe("returns a TransformStream and", () => {
     it("calls `predicate` with each chunk value and index", async () => {

--- a/transform/exhaust_map.ts
+++ b/transform/exhaust_map.ts
@@ -44,7 +44,7 @@ export function exhaustMap<I, O>(
   project: ProjectFn<I, StreamSource<O>>,
 ): TransformStream<I, O> {
   if (typeof project !== "function") {
-    throw new TypeError("No project function found");
+    throw new TypeError("'project' is not a function");
   }
 
   const aborter = new AbortController();

--- a/transform/exhaust_map_test.ts
+++ b/transform/exhaust_map_test.ts
@@ -86,6 +86,7 @@ describe("exhaustMap()", () => {
         assertThrows(
           () => exhaustMap(project),
           TypeError,
+          "'project' is not a function",
         );
       });
     }

--- a/transform/exhaust_map_test.ts
+++ b/transform/exhaust_map_test.ts
@@ -79,6 +79,7 @@ describe("exhaustMap()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => [])],
     ];
     for (const [name, project] of tests) {
       it(name, () => {

--- a/transform/filter.ts
+++ b/transform/filter.ts
@@ -58,6 +58,9 @@ export function filter<T>(
 export function filter<T>(
   predicate: (value: T, index: number) => boolean,
 ): TransformStream<T, T> {
+  if (typeof predicate !== "function") {
+    throw new TypeError("'predicate' is not a function");
+  }
   let index = -1;
   return new TransformStream({
     transform(chunk, controller) {

--- a/transform/filter_test.ts
+++ b/transform/filter_test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "#bdd";
-import { assertInstanceOf } from "@std/assert";
+import { assertInstanceOf, assertThrows } from "@std/assert";
 import { assertEquals } from "@std/assert";
 import { assertType, type IsExact } from "@std/testing/types";
 import { spy } from "@std/testing/mock";
@@ -30,6 +30,27 @@ describe("filter()", () => {
       assertType<IsExact<typeof output, ReadableStream<X>>>(true);
       assertInstanceOf(output, ReadableStream);
     });
+  });
+  describe("throws if `options.predicate` is", () => {
+    // deno-lint-ignore no-explicit-any
+    const tests: [name: string, predicate: any][] = [
+      ["null", null],
+      ["undefined", undefined],
+      ["string", "foo"],
+      ["number", 42],
+      ["object", { foo: 42 }],
+      ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => true)],
+    ];
+    for (const [name, predicate] of tests) {
+      it(name, () => {
+        assertThrows(
+          () => filter(predicate),
+          TypeError,
+          "'predicate' is not a function",
+        );
+      });
+    }
   });
   describe("returns a TransformStream and", () => {
     it("calls `predicate` with each chunk value and index", async () => {

--- a/transform/map.ts
+++ b/transform/map.ts
@@ -37,7 +37,7 @@ export function map<I, O>(
   project: ProjectFn<I, O>,
 ): TransformStream<I, Awaited<O>> {
   if (typeof project !== "function") {
-    throw new TypeError("No project function found");
+    throw new TypeError("'project' is not a function");
   }
   let index = -1;
   return new TransformStream({

--- a/transform/map_test.ts
+++ b/transform/map_test.ts
@@ -39,6 +39,7 @@ describe("map()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => 0)],
     ];
     for (const [name, project] of tests) {
       it(name, () => {

--- a/transform/map_test.ts
+++ b/transform/map_test.ts
@@ -46,6 +46,7 @@ describe("map()", () => {
         assertThrows(
           () => map(project),
           TypeError,
+          "'project' is not a function",
         );
       });
     }

--- a/transform/max.ts
+++ b/transform/max.ts
@@ -26,11 +26,15 @@ import { reduce } from "./reduce.ts";
  * @returns A TransformStream that emits largest value.
  */
 export function max<T>(
-  comparer?: (a: T, b: T) => number,
-): TransformStream<T, T> {
-  return reduce(
-    comparer
-      ? ((a, b) => comparer(a, b) > 0 ? a : b)
-      : ((a, b) => a > b ? a : b),
-  );
+  comparer?: (a: T, b: T, index: number) => number,
+): TransformStream<T | Promise<T>, T> {
+  if (comparer === undefined) {
+    return reduce((a: T, b: T): T => a > b ? a : b);
+  }
+  if (typeof comparer === "function") {
+    return reduce(
+      (a: T, b: T, index: number): T => comparer(a, b, index) > 0 ? a : b,
+    );
+  }
+  throw new TypeError("'comparer' is not a function");
 }

--- a/transform/max_test.ts
+++ b/transform/max_test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "#bdd";
-import { assertInstanceOf } from "@std/assert";
+import { assertInstanceOf, assertThrows } from "@std/assert";
 import { assertType, type IsExact } from "@std/testing/types";
 import { delay } from "@std/async/delay";
 import { testStream } from "@milly/streamtest";
@@ -14,6 +14,26 @@ describe("max()", () => {
 
     assertType<IsExact<typeof output, ReadableStream<X>>>(true);
     assertInstanceOf(output, ReadableStream);
+  });
+  describe("throws if `comparer` is", () => {
+    // deno-lint-ignore no-explicit-any
+    const tests: [name: string, comparer: any][] = [
+      ["null", null],
+      ["string", "foo"],
+      ["number", 42],
+      ["object", { foo: 42 }],
+      ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => 0)],
+    ];
+    for (const [name, comparer] of tests) {
+      it(name, () => {
+        assertThrows(
+          () => max(comparer),
+          TypeError,
+          "'comparer' is not a function",
+        );
+      });
+    }
   });
   describe("returns a TransformStream and", () => {
     it("emits largest chunk", async () => {

--- a/transform/merge_map.ts
+++ b/transform/merge_map.ts
@@ -49,7 +49,7 @@ export function mergeMap<I, O>(
   },
 ): TransformStream<I, O> {
   if (typeof project !== "function") {
-    throw new TypeError("No project function found");
+    throw new TypeError("'project' is not a function");
   }
   const { concurrent = Infinity } = options ?? {};
 

--- a/transform/merge_map_test.ts
+++ b/transform/merge_map_test.ts
@@ -86,6 +86,7 @@ describe("mergeMap()", () => {
         assertThrows(
           () => mergeMap(project),
           TypeError,
+          "'project' is not a function",
         );
       });
     }

--- a/transform/merge_map_test.ts
+++ b/transform/merge_map_test.ts
@@ -79,6 +79,7 @@ describe("mergeMap()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => [])],
     ];
     for (const [name, project] of tests) {
       it(name, () => {

--- a/transform/min.ts
+++ b/transform/min.ts
@@ -26,11 +26,15 @@ import { reduce } from "./reduce.ts";
  * @returns A TransformStream that emits smallest value.
  */
 export function min<T>(
-  comparer?: (a: T, b: T) => number,
-): TransformStream<T, T> {
-  return reduce(
-    comparer
-      ? ((a, b) => comparer(a, b) < 0 ? a : b)
-      : ((a, b) => a < b ? a : b),
-  );
+  comparer?: (a: T, b: T, index: number) => number,
+): TransformStream<T | Promise<T>, T> {
+  if (comparer === undefined) {
+    return reduce((a: T, b: T): T => a < b ? a : b);
+  }
+  if (typeof comparer === "function") {
+    return reduce(
+      (a: T, b: T, index: number): T => comparer(a, b, index) < 0 ? a : b,
+    );
+  }
+  throw new TypeError("'comparer' is not a function");
 }

--- a/transform/min_test.ts
+++ b/transform/min_test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "#bdd";
-import { assertInstanceOf } from "@std/assert";
+import { assertInstanceOf, assertThrows } from "@std/assert";
 import { assertType, type IsExact } from "@std/testing/types";
 import { delay } from "@std/async/delay";
 import { testStream } from "@milly/streamtest";
@@ -14,6 +14,26 @@ describe("min()", () => {
 
     assertType<IsExact<typeof output, ReadableStream<X>>>(true);
     assertInstanceOf(output, ReadableStream);
+  });
+  describe("throws if `comparer` is", () => {
+    // deno-lint-ignore no-explicit-any
+    const tests: [name: string, comparer: any][] = [
+      ["null", null],
+      ["string", "foo"],
+      ["number", 42],
+      ["object", { foo: 42 }],
+      ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => 0)],
+    ];
+    for (const [name, comparer] of tests) {
+      it(name, () => {
+        assertThrows(
+          () => min(comparer),
+          TypeError,
+          "'comparer' is not a function",
+        );
+      });
+    }
   });
   describe("returns a TransformStream and", () => {
     it("emits smallest chunk", async () => {

--- a/transform/reduce.ts
+++ b/transform/reduce.ts
@@ -71,7 +71,7 @@ export function reduce<I, A, V>(
   ...args: [initialValue?: V]
 ): TransformStream<I, I | A | V> {
   if (typeof accumulator !== "function") {
-    throw new TypeError("No accumulator function found");
+    throw new TypeError("'accumulator' is not a function");
   }
   let index = 0;
   let acc: I | A | V;

--- a/transform/reduce_test.ts
+++ b/transform/reduce_test.ts
@@ -40,6 +40,7 @@ describe("reduce()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => 0)],
     ];
     for (const [name, accumulator] of tests) {
       it(name, () => {

--- a/transform/reduce_test.ts
+++ b/transform/reduce_test.ts
@@ -47,6 +47,7 @@ describe("reduce()", () => {
         assertThrows(
           () => reduce(accumulator),
           TypeError,
+          "'accumulator' is not a function",
         );
       });
     }

--- a/transform/scan.ts
+++ b/transform/scan.ts
@@ -71,7 +71,7 @@ export function scan<I, A, V>(
   ...args: [initialValue?: V]
 ): TransformStream<I, I | A> {
   if (typeof accumulator !== "function") {
-    throw new TypeError("No accumulator function found");
+    throw new TypeError("'accumulator' is not a function");
   }
   let index = 0;
   let acc: I | A | V;

--- a/transform/scan_test.ts
+++ b/transform/scan_test.ts
@@ -45,6 +45,7 @@ describe("scan()", () => {
         assertThrows(
           () => scan(accumulator),
           TypeError,
+          "'accumulator' is not a function",
         );
       });
     }

--- a/transform/scan_test.ts
+++ b/transform/scan_test.ts
@@ -38,6 +38,7 @@ describe("scan()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => 0)],
     ];
     for (const [name, accumulator] of tests) {
       it(name, () => {

--- a/transform/switch_map.ts
+++ b/transform/switch_map.ts
@@ -45,7 +45,7 @@ export function switchMap<I, O>(
   project: ProjectFn<I, StreamSource<O>>,
 ): TransformStream<I, O> {
   if (typeof project !== "function") {
-    throw new TypeError("No project function found");
+    throw new TypeError("'project' is not a function");
   }
 
   const SWITCH = {};

--- a/transform/switch_map_test.ts
+++ b/transform/switch_map_test.ts
@@ -79,6 +79,7 @@ describe("switchMap()", () => {
       ["number", 42],
       ["object", { foo: 42 }],
       ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => [])],
     ];
     for (const [name, project] of tests) {
       it(name, () => {

--- a/transform/switch_map_test.ts
+++ b/transform/switch_map_test.ts
@@ -86,6 +86,7 @@ describe("switchMap()", () => {
         assertThrows(
           () => switchMap(project),
           TypeError,
+          "'project' is not a function",
         );
       });
     }

--- a/writable/for_each.ts
+++ b/writable/for_each.ts
@@ -29,6 +29,9 @@ import type { WriteFn } from "../types.ts";
  * @returns A WritableStream that calls `fn` one time for each chunk written.
  */
 export function forEach<T>(fn: WriteFn<T>): WritableStream<T> {
+  if (typeof fn !== "function") {
+    throw new TypeError("'fn' is not a function");
+  }
   let index = 0;
   return new WritableStream({
     write(chunk) {

--- a/writable/for_each_test.ts
+++ b/writable/for_each_test.ts
@@ -1,5 +1,10 @@
 import { describe, it } from "#bdd";
-import { assertEquals, assertInstanceOf, assertRejects } from "@std/assert";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
 import { assertType, type IsExact } from "@std/testing/types";
 import { assertSpyCallArgs, assertSpyCalls, spy } from "@std/testing/mock";
 import { delay } from "@std/async/delay";
@@ -17,6 +22,27 @@ describe("forEach()", () => {
       assertType<IsExact<typeof actual, WritableStream<X>>>(true);
       assertInstanceOf(actual, WritableStream);
     });
+  });
+  describe("throws if `fn` is", () => {
+    // deno-lint-ignore no-explicit-any
+    const tests: [name: string, fn: any][] = [
+      ["null", null],
+      ["undefined", undefined],
+      ["string", "foo"],
+      ["number", 42],
+      ["object", { foo: 42 }],
+      ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => {})],
+    ];
+    for (const [name, fn] of tests) {
+      it(name, () => {
+        assertThrows(
+          () => forEach(fn),
+          TypeError,
+          "'fn' is not a function",
+        );
+      });
+    }
   });
   describe("returns a WritableStream and", () => {
     it("calls `fn`", async () => {

--- a/writable/post_message.ts
+++ b/writable/post_message.ts
@@ -105,6 +105,9 @@ export function postMessage<T>(
     ? { transfer: optionsOrTransfer }
     : optionsOrTransfer;
   const { transfer } = options ?? {};
+  if (transfer !== undefined && typeof transfer !== "function") {
+    throw new TypeError("'transfer' is not a function");
+  }
   let index = 0;
   return new WritableStream({
     write(chunk) {

--- a/writable/post_message_test.ts
+++ b/writable/post_message_test.ts
@@ -3,6 +3,7 @@ import {
   assertEquals,
   assertInstanceOf,
   assertRejects,
+  assertThrows,
   unimplemented,
 } from "@std/assert";
 import { assertType, type IsExact } from "@std/testing/types";
@@ -38,6 +39,30 @@ describe("postMessage()", () => {
       assertType<IsExact<typeof actual, WritableStream<X>>>(true);
       assertInstanceOf(actual, WritableStream);
     });
+  });
+  describe("throws if `transfer` is", () => {
+    const target: PostMessageTarget = {
+      postMessage: () => unimplemented(),
+    };
+
+    // deno-lint-ignore no-explicit-any
+    const tests: [name: string, transfer: any][] = [
+      ["null", null],
+      ["string", "foo"],
+      ["number", 42],
+      ["object", { foo: 42 }],
+      ["symbol", Symbol.for("some-symbol")],
+      ["Promise", Promise.resolve(() => 0)],
+    ];
+    for (const [name, transfer] of tests) {
+      it(name, () => {
+        assertThrows(
+          () => postMessage(target, { transfer }),
+          TypeError,
+          "'transfer' is not a function",
+        );
+      });
+    }
   });
   describe("returns a WritableStream and", () => {
     it("posts data as a message to `target`", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation checks to ensure specific parameters are functions in `fromEvent`, `fromMessage`, `every`, `filter`, `reduce`, `scan`, and `switchMap` functions.
  - Updated error messages for better clarity in various functions like `defer`, `fromEvent`, `fromMessage`, `every`, `filter`, `map`, `reduce`, `scan`, and `switchMap`.

- **Bug Fixes**
  - Enhanced error handling for invalid parameter types in several functions, ensuring more specific error messages.

- **Tests**
  - Added new test cases to validate additional scenarios and ensure proper error handling for non-function parameters across multiple functions.
  - Updated existing test cases to check for specific error messages and parameter type validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->