### PR TITLE
feat: rename `arrayFrom` to `toArray`

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -52,8 +52,8 @@
     "./writable/post-message": "./writable/post_message.ts",
     "./types": "./types.ts",
     "./util": "./util/mod.ts",
-    "./util/array-from": "./util/array_from.ts",
     "./util/pull": "./util/pull.ts",
+    "./util/to-array": "./util/to_array.ts",
     "./util/write": "./util/write.ts"
   },
   "test": {
@@ -144,8 +144,8 @@
     "@milly/streams/transform/transform": "./transform/transform.ts",
     "@milly/streams/types": "./types.ts",
     "@milly/streams/util": "./util/mod.ts",
-    "@milly/streams/util/array-from": "./util/array_from.ts",
     "@milly/streams/util/pull": "./util/pull.ts",
+    "@milly/streams/util/to-array": "./util/to_array.ts",
     "@milly/streams/util/write": "./util/write.ts",
     "@milly/streams/writable": "./writable/mod.ts",
     "@milly/streams/writable/for-each": "./writable/for_each.ts",

--- a/util/mod.ts
+++ b/util/mod.ts
@@ -5,6 +5,6 @@
  * @module
  */
 
-export * from "./array_from.ts";
 export * from "./pull.ts";
+export * from "./to_array.ts";
 export * from "./write.ts";

--- a/util/to_array.ts
+++ b/util/to_array.ts
@@ -1,5 +1,5 @@
 /**
- * Provides {@link arrayFrom}.
+ * Provides {@link toArray}.
  *
  * @module
  */
@@ -21,11 +21,11 @@ import { getIterator, iteratorNext } from "../internal/iterator.ts";
  * (see {@link https://github.com/tc39/ecma262/pull/2600 | tc39/ecma262#2600}).
  *
  * ```ts
- * import { arrayFrom } from "@milly/streams/util/array-from";
+ * import { toArray } from "@milly/streams/util/to-array";
  * import { from } from "@milly/streams/readable/from";
  *
  * const stream = from([1, 2, 3]);
- * const array = arrayFrom(stream);
+ * const array = toArray(stream);
  * console.log(array); // [1, 2, 3]
  * ```
  *
@@ -34,14 +34,14 @@ import { getIterator, iteratorNext } from "../internal/iterator.ts";
  * @param mapFn A function to call on every chunk of the stream, and return value is added to the array instead (after being awaited).
  * @returns A new Promise whose fulfillment value is a new Array instance.
  */
-export async function arrayFrom<T, R>(
+export async function toArray<T, R>(
   stream: StreamSource<T> | ArrayLike<T | Promise<T>>,
   mapFn: (element: T, index: number) => R,
 ): Promise<Awaited<R>[]>;
-export async function arrayFrom<T>(
+export async function toArray<T>(
   stream: StreamSource<T> | ArrayLike<T | Promise<T>>,
 ): Promise<Awaited<T>[]>;
-export async function arrayFrom<T, R>(
+export async function toArray<T, R>(
   stream: StreamSource<T> | ArrayLike<T | Promise<T>>,
   mapFn?: (element: T, index: number) => R,
 ): Promise<Awaited<T | R>[]> {

--- a/util/to_array_test.ts
+++ b/util/to_array_test.ts
@@ -7,14 +7,14 @@ import {
   spy,
 } from "@std/testing/mock";
 import { from } from "../readable/from.ts";
-import { arrayFrom } from "./array_from.ts";
+import { toArray } from "./to_array.ts";
 
-describe("arrayFrom()", () => {
+describe("toArray()", () => {
   describe("if `stream` is ReadableStream", () => {
     it("returns the all chunk in the stream", async () => {
       const stream = from([1, 2, 3]);
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, [1, 2, 3]);
       assertFalse(stream.locked, "should stream unlocked");
@@ -22,7 +22,7 @@ describe("arrayFrom()", () => {
     it("returns [] if the stream is empty", async () => {
       const stream = from([]);
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, []);
       assertFalse(stream.locked, "should stream unlocked");
@@ -30,7 +30,7 @@ describe("arrayFrom()", () => {
     it("throws if the stream is rejected", async () => {
       const stream = from([1, 2, Promise.reject("error")]);
 
-      const actual = await assertRejects(() => arrayFrom(stream));
+      const actual = await assertRejects(() => toArray(stream));
 
       assertEquals(actual, "error");
       assertFalse(stream.locked, "should stream unlocked");
@@ -40,7 +40,7 @@ describe("arrayFrom()", () => {
         const stream = from([1, 2, 3]);
         const mapFn = spy(returnsNext([10, Promise.resolve(11), 12]));
 
-        const actual = await arrayFrom(stream, mapFn);
+        const actual = await toArray(stream, mapFn);
 
         assertEquals(actual, [10, 11, 12]);
         assertSpyCalls(mapFn, 3);
@@ -64,7 +64,7 @@ describe("arrayFrom()", () => {
         const error = new Error("error");
         const mapFn = spy(returnsNext([10, 11, error]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, error);
         assertFalse(stream.locked, "should stream unlocked");
@@ -84,7 +84,7 @@ describe("arrayFrom()", () => {
         });
         const mapFn = spy(returnsNext([10, 11, Promise.reject("error")]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, "error");
         assertFalse(stream.locked, "should stream unlocked");
@@ -107,7 +107,7 @@ describe("arrayFrom()", () => {
         },
       };
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, [1, 2, 3]);
       assert(streamClosed, "should closes async iterator");
@@ -121,7 +121,7 @@ describe("arrayFrom()", () => {
         },
       };
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, []);
       assert(streamClosed, "should closes async iterator");
@@ -140,7 +140,7 @@ describe("arrayFrom()", () => {
         },
       };
 
-      const actual = await assertRejects(() => arrayFrom(stream));
+      const actual = await assertRejects(() => toArray(stream));
 
       assertEquals(actual, "error");
       assert(streamClosed, "should closes async iterator");
@@ -161,7 +161,7 @@ describe("arrayFrom()", () => {
         };
         const mapFn = spy(returnsNext([10, Promise.resolve(11), 12]));
 
-        const actual = await arrayFrom(stream, mapFn);
+        const actual = await toArray(stream, mapFn);
 
         assertEquals(actual, [10, 11, 12]);
         assertSpyCalls(mapFn, 3);
@@ -186,7 +186,7 @@ describe("arrayFrom()", () => {
         const error = new Error("error");
         const mapFn = spy(returnsNext([10, 11, error]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, error);
         assert(streamClosed, "should closes async iterator");
@@ -206,7 +206,7 @@ describe("arrayFrom()", () => {
         };
         const mapFn = spy(returnsNext([10, 11, Promise.reject("error")]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, "error");
         assert(streamClosed, "should closes async iterator");
@@ -228,7 +228,7 @@ describe("arrayFrom()", () => {
         },
       };
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, [1, 2, 3]);
       assert(streamClosed, "should closes sync iterator");
@@ -242,7 +242,7 @@ describe("arrayFrom()", () => {
         },
       };
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, []);
       assert(streamClosed, "should closes sync iterator");
@@ -261,7 +261,7 @@ describe("arrayFrom()", () => {
         },
       };
 
-      const actual = await assertRejects(() => arrayFrom(stream));
+      const actual = await assertRejects(() => toArray(stream));
 
       assertEquals(actual, "error");
       // Ref: https://github.com/tc39/ecma262/pull/2600
@@ -283,7 +283,7 @@ describe("arrayFrom()", () => {
         };
         const mapFn = spy(returnsNext([10, Promise.resolve(11), 12]));
 
-        const actual = await arrayFrom(stream, mapFn);
+        const actual = await toArray(stream, mapFn);
 
         assertEquals(actual, [10, 11, 12]);
         assertSpyCalls(mapFn, 3);
@@ -308,7 +308,7 @@ describe("arrayFrom()", () => {
         const error = new Error("error");
         const mapFn = spy(returnsNext([10, 11, error]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, error);
         assert(streamClosed, "should closes sync iterator");
@@ -328,7 +328,7 @@ describe("arrayFrom()", () => {
         };
         const mapFn = spy(returnsNext([10, 11, Promise.reject("error")]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, "error");
         assert(streamClosed, "should closes sync iterator");
@@ -344,7 +344,7 @@ describe("arrayFrom()", () => {
         2: Promise.resolve(3),
       };
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, [1, 2, 3]);
     });
@@ -353,7 +353,7 @@ describe("arrayFrom()", () => {
         length: 0,
       };
 
-      const actual = await arrayFrom(stream);
+      const actual = await toArray(stream);
 
       assertEquals(actual, []);
     });
@@ -365,7 +365,7 @@ describe("arrayFrom()", () => {
         2: Promise.reject("error"),
       };
 
-      const actual = await assertRejects(() => arrayFrom(stream));
+      const actual = await assertRejects(() => toArray(stream));
 
       assertEquals(actual, "error");
     });
@@ -379,7 +379,7 @@ describe("arrayFrom()", () => {
         };
         const mapFn = spy(returnsNext([10, Promise.resolve(11), 12]));
 
-        const actual = await arrayFrom(stream, mapFn);
+        const actual = await toArray(stream, mapFn);
 
         assertEquals(actual, [10, 11, 12]);
         assertSpyCalls(mapFn, 3);
@@ -397,7 +397,7 @@ describe("arrayFrom()", () => {
         const error = new Error("error");
         const mapFn = spy(returnsNext([10, 11, error]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, error);
       });
@@ -410,7 +410,7 @@ describe("arrayFrom()", () => {
         };
         const mapFn = spy(returnsNext([10, 11, Promise.reject("error")]));
 
-        const actual = await assertRejects(() => arrayFrom(stream, mapFn));
+        const actual = await assertRejects(() => toArray(stream, mapFn));
 
         assertEquals(actual, "error");
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed `arrayFrom` function to `toArray` across the application for better readability and consistency.
  - Updated all relevant imports and exports to reflect the function name change.
  
- **Tests**
  - Modified test files to use `toArray` instead of `arrayFrom`, ensuring all tests remain accurate and functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->