### PR TITLE
fix: wait cancel promise

### DIFF
--- a/readable/defer.ts
+++ b/readable/defer.ts
@@ -53,11 +53,12 @@ export function defer<T>(inputFactory: FactoryFn<T>): ReadableStream<T> {
         throw e;
       }
     },
-    cancel(reason) {
+    async cancel(reason) {
       if (reader) {
-        reader.cancel(reason);
+        const cancelPromise = reader.cancel(reason);
         reader.releaseLock();
         reader = undefined;
+        await cancelPromise;
       }
     },
   }, { highWaterMark: 0 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability and handling of stream cancellations by making the `cancel` function asynchronous.

- **Tests**
  - Added a test case to ensure proper rejection handling in the `defer()` function.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->