### PR TITLE
fix: clear interval when close

### DIFF
--- a/readable/timer.ts
+++ b/readable/timer.ts
@@ -36,17 +36,16 @@ export function timer(delay: number): ReadableStream<0>;
 export function timer(delay: number, interval: number): ReadableStream<number>;
 export function timer(delay: number, interval = -1): ReadableStream<number> {
   const { promise, resolve } = deferred<void>();
-  let timer: number | undefined;
+  let timer = 0;
+  let intervalTimer = 0;
   let count = 0;
   return new ReadableStream({
     pull(controller) {
       timer = setTimeout(() => {
         if (0 <= interval) {
-          timer = setInterval(() => {
+          intervalTimer = setInterval(() => {
             controller.enqueue(count++);
           }, interval);
-        } else {
-          timer = undefined;
         }
         controller.enqueue(count++);
         if (interval < 0) {
@@ -58,6 +57,7 @@ export function timer(delay: number, interval = -1): ReadableStream<number> {
     },
     cancel() {
       clearTimeout(timer);
+      clearInterval(intervalTimer);
       resolve();
     },
   });


### PR DESCRIPTION
Fixes leak.
```
error: Leaks detected:
  - An interval was started in this test, but never completed. This is often caused by not calling `clearInterval`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced timer functionality for improved clarity and management of intervals.
	- Introduced separate handling for interval timing to reduce confusion.

- **Bug Fixes**
	- Updated logic to ensure both timeout and interval are properly managed when canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->