### PR TITLE
test(docs): replace console.log with assertions in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ import { switchMap } from "@milly/streams/transform/switch-map";
 import { take } from "@milly/streams/transform/take";
 import { forEach } from "@milly/streams/writable/for-each";
 import { postMessage } from "@milly/streams/writable/post-message";
+import { assertEquals } from "@std/assert";
 
 async function* gen() {
   yield 1;
@@ -31,24 +32,25 @@ const { port1, port2 } = new MessageChannel();
 from(gen())
   .pipeThrough(switchMap((chunk) => [chunk, typeof chunk]))
   .pipeTo(postMessage(port1))
-  .finally(() => {
-    port1.close();
-  });
+  .finally(() => port1.close());
+
+const result: unknown[] = [];
 
 await fromMessage(port2)
   .pipeThrough(take(6))
   .pipeTo(forEach((chunk) => {
-    console.log(chunk);
+    result.push(chunk);
   }))
-  .finally(() => {
-    port2.close();
-  });
-// output: 1
-// output: number
-// output: foo
-// output: string
-// output: true
-// output: boolean
+  .finally(() => port2.close());
+
+assertEquals(result, [
+  1,
+  "number",
+  "foo",
+  "string",
+  true,
+  "boolean",
+]);
 ```
 
 ## License

--- a/readable/concat_with.ts
+++ b/readable/concat_with.ts
@@ -20,6 +20,7 @@ import { concatAll } from "../transform/concat_all.ts";
  * ```ts
  * import { concatWith } from "@milly/streams/readable/concat-with";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const output = concatWith([
  *   [3, 5],
@@ -27,7 +28,7 @@ import { concatAll } from "../transform/concat_all.ts";
  *   from([10, 20, 30]),
  * ]);
  * const result = await Array.fromAsync(output);
- * console.log(result); // [3, 5, 9, 10, 20, 30]
+ * assertEquals(result, [3, 5, 9, 10, 20, 30]);
  * ```
  */
 export function concatWith<T>(

--- a/readable/defer.ts
+++ b/readable/defer.ts
@@ -19,16 +19,17 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  * @example
  * ```ts
  * import { defer } from "@milly/streams/readable/defer";
+ * import { assertEquals } from "@std/assert";
  *
  * let isFactoryCalled = false;
- * const output = defer(() => {
+ * const output = defer(function* () {
  *   isFactoryCalled = true;
- *   return Math.random() > 0.5 ? [3, 4, 5] : [Promise.resolve(42)];
+ *   yield* [3, 4, 5];
  * });
- * console.log(isFactoryCalled); // false
+ * assertEquals(isFactoryCalled, false);
  * const result = await Array.fromAsync(output);
- * console.log(isFactoryCalled); // true
- * console.log(result); // [3, 4, 5] or [42]
+ * assertEquals(isFactoryCalled, true);
+ * assertEquals(result, [3, 4, 5]);
  * ```
  */
 export function defer<T>(inputFactory: FactoryFn<T>): ReadableStream<T> {

--- a/readable/empty.ts
+++ b/readable/empty.ts
@@ -11,9 +11,10 @@
  * @example
  * ```ts
  * import { empty } from "@milly/streams/readable/empty";
+ * import { assertEquals } from "@std/assert";
  *
  * const result = await Array.fromAsync(empty());
- * console.log(result); // []
+ * assertEquals(result, []);
  * ```
  */
 export function empty(): ReadableStream<never> {

--- a/readable/error.ts
+++ b/readable/error.ts
@@ -11,11 +11,12 @@
  * @example
  * ```ts
  * import { error } from "@milly/streams/readable/error";
+ * import { assertEquals } from "@std/assert";
  *
  * try {
  *   await Array.fromAsync(error("reason"));
  * } catch (e) {
- *   console.log(e); // "reason"
+ *   assertEquals(e, "reason");
  * }
  * ```
  */

--- a/readable/from.ts
+++ b/readable/from.ts
@@ -22,10 +22,11 @@ const NOOP = () => {};
  * @example
  * ```ts
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const output = from([3, Promise.resolve(8), 42]);
  * const result = await Array.fromAsync(output);
- * console.log(result); // [3, 8, 42]
+ * assertEquals(result, [3, 8, 42]);
  * ```
  */
 export function from<T>(input: StreamSource<T>): ReadableStream<T> {

--- a/readable/from_event.ts
+++ b/readable/from_event.ts
@@ -61,6 +61,7 @@ export interface FromEventOptions<E, R> extends AddEventListenerOptions {
  * @example
  * ```ts
  * import { fromEvent } from "@milly/streams/readable/from-event";
+ * import { assertEquals } from "@std/assert";
  *
  * const abortController = new AbortController();
  * const { signal } = abortController;
@@ -72,7 +73,7 @@ export interface FromEventOptions<E, R> extends AddEventListenerOptions {
  *   once: true,
  * });
  * const result = await Array.fromAsync(output);
- * console.log(result); // ["foo"]
+ * assertEquals(result, ["foo"]);
  * ```
  */
 export function fromEvent<E, R = E>(
@@ -99,6 +100,7 @@ export function fromEvent<E, R = E>(
  * ```ts
  * import { fromEvent } from "@milly/streams/readable/from-event";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * const abortController = new AbortController();
  * const { signal } = abortController;
@@ -108,7 +110,7 @@ export function fromEvent<E, R = E>(
  * const output = fromEvent(signal, "abort", () => signal.reason)
  *     .pipeThrough(take(1));
  * const result = await Array.fromAsync(output);
- * console.log(result); // ["foo"]
+ * assertEquals(result, ["foo"]);
  * ```
  */
 export function fromEvent<E, R>(

--- a/readable/from_message.ts
+++ b/readable/from_message.ts
@@ -54,6 +54,7 @@ export interface FromMessageOptions<T, R> {
  * ```ts
  * import { fromMessage } from "@milly/streams/readable/from-message";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * const { port1, port2 } = new MessageChannel();
  * const output = fromMessage(port1).pipeThrough(take(3));
@@ -62,7 +63,7 @@ export interface FromMessageOptions<T, R> {
  * port2.postMessage(true);
  * port2.close();
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, "foo", true]
+ * assertEquals(result, [1, "foo", true]);
  * port1.close();
  * ```
  */
@@ -89,6 +90,7 @@ export function fromMessage<T, R = T>(
  * ```ts
  * import { fromMessage } from "@milly/streams/readable/from-message";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * const { port1, port2 } = new MessageChannel();
  * const output = fromMessage(port1).pipeThrough(take(3));
@@ -97,7 +99,7 @@ export function fromMessage<T, R = T>(
  * port2.postMessage(true);
  * port2.close();
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, "foo", true]
+ * assertEquals(result, [1, "foo", true]);
  * port1.close();
  * ```
  */

--- a/readable/interval.ts
+++ b/readable/interval.ts
@@ -16,11 +16,12 @@ import { timer } from "./timer.ts";
  * ```ts
  * import { interval } from "@milly/streams/readable/interval";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // output : --100ms-> 0 --100ms-> 1 --100ms-> 2 --100ms-> 3 |
  * const output = interval(100).pipeThrough(take(4));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 1, 2, 3]
+ * assertEquals(result, [0, 1, 2, 3]);
  * ```
  */
 export function interval(period: number): ReadableStream<number> {

--- a/readable/merge_with.ts
+++ b/readable/merge_with.ts
@@ -23,6 +23,7 @@ import { mergeAll } from "../transform/merge_all.ts";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
  * import { timer } from "@milly/streams/readable/timer";
+ * import { assertEquals } from "@std/assert";
  *
  * // input[0] : 1 --300ms--------------> 1 --300ms------------> 1
  * // input[1] : 2 --200ms-----> 2 --200ms-----> 2 --200ms-----> 2
@@ -34,7 +35,7 @@ import { mergeAll } from "../transform/merge_all.ts";
  *   timer(500, 200).pipeThrough(pipe(take(2), map(() => 3))),
  * ]);
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 2, 2, 1, 2, 3, 1, 2, 3]
+ * assertEquals(result, [1, 2, 2, 1, 2, 3, 1, 2, 3]);
  * ```
  */
 export function mergeWith<T>(

--- a/readable/range.ts
+++ b/readable/range.ts
@@ -17,10 +17,11 @@ import { empty } from "./empty.ts";
  * @example
  * ```ts
  * import { range } from "@milly/streams/readable/range";
+ * import { assertEquals } from "@std/assert";
  *
  * const output = range(8, 5);
  * const result = await Array.fromAsync(output);
- * console.log(result); // [8, 9, 10, 11, 12]
+ * assertEquals(result, [8, 9, 10, 11, 12]);
  * ```
  */
 export function range(count: number): ReadableStream<number>;

--- a/readable/timer.ts
+++ b/readable/timer.ts
@@ -20,16 +20,17 @@ import { deferred } from "../internal/deferred.ts";
  * ```ts
  * import { timer } from "@milly/streams/readable/timer";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // output1 : --100ms-> 0
  * const output1 = timer(100);
  * const result1 = await Array.fromAsync(output1);
- * console.log(result1); // [0]
+ * assertEquals(result1, [0]);
  *
  * // output2 : --200ms-> 0 --50ms-> 1 --50ms-> 2 --50ms-> 3
  * const output2 = timer(200, 50).pipeThrough(take(4));
  * const result2 = await Array.fromAsync(output2);
- * console.log(result2); // [0, 1, 2, 3]
+ * assertEquals(result2, [0, 1, 2, 3]);
  * ```
  */
 export function timer(delay: number): ReadableStream<0>;

--- a/transform/abort.ts
+++ b/transform/abort.ts
@@ -14,14 +14,14 @@
  * ```ts
  * import { abort } from "@milly/streams/transform/abort";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals, assertRejects } from "@std/assert";
  *
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(abort("reason"));
- * try {
+ * const error = await assertRejects(async () => {
  *   await Array.fromAsync(output);
- * } catch (e) {
- *   console.log(e); // "reason"
- * }
+ * });
+ * assertEquals(error, "reason");
  * ```
  */
 export function abort(reason?: unknown): TransformStream<unknown, never> {

--- a/transform/buffer.ts
+++ b/transform/buffer.ts
@@ -22,6 +22,7 @@ import { map } from "./map.ts";
  * import { buffer } from "@milly/streams/transform/buffer";
  * import { timer } from "@milly/streams/readable/timer";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // source  : 0 ----100ms----> 1 ----100ms----> 2 ----100ms------> 3   |
  * // emitter : -----150ms---------> 0      --100ms--> 1   |
@@ -30,7 +31,7 @@ import { map } from "./map.ts";
  * const emitter = timer(150, 100).pipeThrough(take(2));
  * const output = source.pipeThrough(buffer(emitter));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [[0, 1], [2], [3]]
+ * assertEquals(result, [[0, 1], [2], [3]]);
  * ```
  */
 export function buffer<T>(

--- a/transform/buffer_count.ts
+++ b/transform/buffer_count.ts
@@ -17,11 +17,12 @@
  * ```ts
  * import { bufferCount } from "@milly/streams/transform/buffer-count";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 4, 5, 6, 7, 8]);
  * const output = source.pipeThrough(bufferCount(3));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [[1, 2, 3], [4, 5, 6], [7, 8]]
+ * assertEquals(result, [[1, 2, 3], [4, 5, 6], [7, 8]]);
  * ```
  */
 export function bufferCount<T>(bufferSize: number): TransformStream<T, T[]> {

--- a/transform/concat_all.ts
+++ b/transform/concat_all.ts
@@ -22,6 +22,7 @@ import { mergeMap } from "./merge_map.ts";
  * ```ts
  * import { concatAll } from "@milly/streams/transform/concat-all";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([
  *   [3, 5],
@@ -30,7 +31,7 @@ import { mergeMap } from "./merge_map.ts";
  * ]);
  * const output = source.pipeThrough(concatAll());
  * const result = await Array.fromAsync(output);
- * console.log(result); // [3, 5, 10, 20, 30, "foo"]
+ * assertEquals(result, [3, 5, 10, 20, 30, "foo"]);
  * ```
  */
 export function concatAll<T>(): TransformStream<StreamSource<T>, T> {

--- a/transform/concat_map.ts
+++ b/transform/concat_map.ts
@@ -27,6 +27,7 @@ import { mergeMap } from "./merge_map.ts";
  * import { map } from "@milly/streams/transform/map";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // source     : 3 5 |
  * // project[0] : -300ms-> 30 -300ms-> 31 |
@@ -40,7 +41,7 @@ import { mergeMap } from "./merge_map.ts";
  *   ))
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [30, 31, 50, 51]
+ * assertEquals(result, [30, 31, 50, 51]);
  * ```
  */
 export function concatMap<I, O>(

--- a/transform/count.ts
+++ b/transform/count.ts
@@ -16,11 +16,12 @@ import { reduce } from "./reduce.ts";
  * ```ts
  * import { count } from "@milly/streams/transform/count";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from(["a", "b", "c", "d"]);
  * const output = source.pipeThrough(count());
  * const result = await Array.fromAsync(output);
- * console.log(result); // [4]
+ * assertEquals(result, [4]);
  * ```
  */
 export function count(): TransformStream<unknown, number> {

--- a/transform/debounce_time.ts
+++ b/transform/debounce_time.ts
@@ -24,6 +24,7 @@ import { debounce, type DebouncedFunction } from "@std/async/debounce";
  * import { debounceTime } from "@milly/streams/transform/debounce-time";
  * import { from } from "@milly/streams/readable/from";
  * import { delay } from "@std/async";
+ * import { assertEquals } from "@std/assert";
  *
  * // source : 0 -100ms-> 1 ---200ms---> 2 3 ---200ms---> 4 |
  * // output :              -150ms-> 1       -150ms-> 3   4 |
@@ -36,7 +37,7 @@ import { debounce, type DebouncedFunction } from "@std/async/debounce";
  * })());
  * const output = source.pipeThrough(debounceTime(150));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 3, 4]
+ * assertEquals(result, [1, 3, 4]);
  * ```
  */
 export function debounceTime<T>(due: number): TransformStream<T, T> {

--- a/transform/default_with.ts
+++ b/transform/default_with.ts
@@ -22,11 +22,12 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  * ```ts
  * import { defaultWith } from "@milly/streams/transform/default-with";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([]);
  * const output = source.pipeThrough(defaultWith(() => [42, 123]));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [42, 123]
+ * assertEquals(result, [42, 123]);
  * ```
  */
 export function defaultWith<I, D = I>(

--- a/transform/delay.ts
+++ b/transform/delay.ts
@@ -21,13 +21,14 @@ import { mergeMap } from "./merge_map.ts";
  * import { delay } from "@milly/streams/transform/delay";
  * import { take } from "@milly/streams/transform/take";
  * import { timer } from "@milly/streams/readable/timer";
+ * import { assertEquals } from "@std/assert";
  *
  * // source : -100ms-> 0 --200ms--> 1 --200ms--> 2 |
  * // output : -400ms--------------------> 0 --200ms--> 1 --200ms--> 2 |
  * const source = timer(100, 300).pipeThrough(take(3));
  * const output = source.pipeThrough(delay(300));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 1, 2]
+ * assertEquals(result, [0, 1, 2]);
  * ```
  */
 export function delay<T>(due: number): TransformStream<T, T> {

--- a/transform/every.ts
+++ b/transform/every.ts
@@ -22,11 +22,12 @@ import type { Falsy } from "../internal/types.ts";
  * ```ts
  * import { every } from "@milly/streams/transform/every";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([2, 4, 6]);
  * const output = source.pipeThrough(every((v) => v % 2 === 0));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [true]
+ * assertEquals(result, [true]);
  * ```
  */
 export function every<T>(

--- a/transform/exhaust_all.ts
+++ b/transform/exhaust_all.ts
@@ -23,6 +23,7 @@ import { exhaustMap } from "./exhaust_map.ts";
  * import { map } from "@milly/streams/transform/map";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // source:timer  : 0 -300ms------> 1 -300ms------> 2 |
  * // source:map[0] : 0 -200ms-> 0 -200ms-> 0 |
@@ -40,7 +41,7 @@ import { exhaustMap } from "./exhaust_map.ts";
  * ));
  * const output = source.pipeThrough(exhaustAll());
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 0, 0, 2, 2, 2]
+ * assertEquals(result, [0, 0, 0, 2, 2, 2]);
  * ```
  */
 export function exhaustAll<T>(): TransformStream<StreamSource<T>, T> {

--- a/transform/exhaust_map.ts
+++ b/transform/exhaust_map.ts
@@ -26,6 +26,7 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  * import { map } from "@milly/streams/transform/map";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // source     : 0 -300ms------> 1 -300ms------> 2 |
  * // project[0] : 0 -200ms-> 0 -200ms-> 0 |
@@ -39,7 +40,7 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  *   ))
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 0, 0, 2, 2, 2]
+ * assertEquals(result, [0, 0, 0, 2, 2, 2]);
  * ```
  */
 export function exhaustMap<I, O>(

--- a/transform/filter.ts
+++ b/transform/filter.ts
@@ -22,13 +22,14 @@ import type { Falsy } from "../internal/types.ts";
  * ```ts
  * import { filter } from "@milly/streams/transform/filter";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, "a", 2, "b", 3, "c"]);
  * const output = source.pipeThrough(
  *   filter((v): v is string => typeof v === "string")
  * );
  * const result = await Array.fromAsync(output);
- * console.log(result); // ["a", "b", "c"]
+ * assertEquals(result, ["a", "b", "c"]);
  * ```
  */
 export function filter<I, O extends I>(
@@ -48,11 +49,12 @@ export function filter<I, O extends I>(
  * ```ts
  * import { filter } from "@milly/streams/transform/filter";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, null, 2, undefined, false, 3]);
  * const output = source.pipeThrough(filter(Boolean));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 2, 3]
+ * assertEquals(result, [1, 2, 3]);
  * ```
  */
 export function filter<T>(
@@ -72,11 +74,12 @@ export function filter<T>(
  * ```ts
  * import { filter } from "@milly/streams/transform/filter";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 4, 5, 6, 7]);
  * const output = source.pipeThrough(filter((v) => v % 2 === 0));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [2, 4, 6]
+ * assertEquals(result, [2, 4, 6]);
  * ```
  */
 export function filter<T>(predicate: PredicateFn<T>): TransformStream<T, T>;

--- a/transform/map.ts
+++ b/transform/map.ts
@@ -27,11 +27,12 @@ import type { ProjectFn } from "../types.ts";
  * ```ts
  * import { map } from "@milly/streams/transform/map";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(map((v) => v * 2));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [2, 4, 6]
+ * assertEquals(result, [2, 4, 6]);
  * ```
  */
 export function map<I, O>(

--- a/transform/max.ts
+++ b/transform/max.ts
@@ -19,11 +19,12 @@ import { reduce } from "./reduce.ts";
  * ```ts
  * import { max } from "@milly/streams/transform/max";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([12, 42, 3, 8, 25]);
  * const output = source.pipeThrough(max());
  * const result = await Array.fromAsync(output);
- * console.log(result); // [42]
+ * assertEquals(result, [42]);
  * ```
  */
 export function max<T>(

--- a/transform/merge_all.ts
+++ b/transform/merge_all.ts
@@ -26,6 +26,7 @@ import { mergeMap } from "./merge_map.ts";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
  * import { timer } from "@milly/streams/readable/timer";
+ * import { assertEquals } from "@std/assert";
  *
  * // source[0] : 0 ------300ms----------> 0 ------300ms--------> 0 |
  * // source[1] : -100ms-> 1 ---200ms----> 1 ---200ms----> 1 |
@@ -38,7 +39,7 @@ import { mergeMap } from "./merge_map.ts";
  * ]);
  * const output = source.pipeThrough(mergeAll());
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 1, 2, 0, 1, 2, 1, 0, 2]
+ * assertEquals(result, [0, 1, 2, 0, 1, 2, 1, 0, 2]);
  * ```
  */
 export function mergeAll<T>(

--- a/transform/merge_map.ts
+++ b/transform/merge_map.ts
@@ -27,6 +27,7 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  * import { map } from "@milly/streams/transform/map";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // source     : 0 -300ms------> 1 -300ms------> 2 |
  * // project[0] : 0 -200ms-> 0 -200ms-> 0 |
@@ -41,7 +42,7 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  *   ))
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 0, 1, 0, 1, 2, 1, 2, 2]
+ * assertEquals(result, [0, 0, 1, 0, 1, 2, 1, 2, 2]);
  * ```
  */
 export function mergeMap<I, O>(

--- a/transform/min.ts
+++ b/transform/min.ts
@@ -19,11 +19,12 @@ import { reduce } from "./reduce.ts";
  * ```ts
  * import { min } from "@milly/streams/transform/min";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([12, 42, 3, 8, 25]);
  * const output = source.pipeThrough(min());
  * const result = await Array.fromAsync(output);
- * console.log(result); // [3]
+ * assertEquals(result, [3]);
  * ```
  */
 export function min<T>(

--- a/transform/pipe.ts
+++ b/transform/pipe.ts
@@ -20,6 +20,7 @@
  * import { interval } from "@milly/streams/readable/interval";
  * import { map } from "@milly/streams/transform/map";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = interval(100);
  * const output = source.pipeThrough(pipe(
@@ -28,7 +29,7 @@
  *   map(value => value * value),
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 9, 25]
+ * assertEquals(result, [1, 9, 25]);
  * ```
  */
 export function pipe<I, O, T1>(

--- a/transform/reduce.ts
+++ b/transform/reduce.ts
@@ -24,13 +24,14 @@ import type { AccumulateFn } from "../types.ts";
  * ```ts
  * import { reduce } from "@milly/streams/transform/reduce";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(reduce(
  *   (prev: number, chunk: number) => prev + chunk
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [6]
+ * assertEquals(result, [6]);
  * ```
  */
 export function reduce<I, A = I>(
@@ -58,6 +59,7 @@ export function reduce<I, A = I>(
  * ```ts
  * import { reduce } from "@milly/streams/transform/reduce";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(reduce(
@@ -65,7 +67,7 @@ export function reduce<I, A = I>(
  *   10
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [16]
+ * assertEquals(result, [16]);
  * ```
  */
 export function reduce<I, A, V = A>(

--- a/transform/scan.ts
+++ b/transform/scan.ts
@@ -24,13 +24,14 @@ import type { AccumulateFn } from "../types.ts";
  * ```ts
  * import { scan } from "@milly/streams/transform/scan";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(scan(
  *   (prev: number, chunk: number) => prev + chunk
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 3, 6]
+ * assertEquals(result, [1, 3, 6]);
  * ```
  */
 export function scan<I, A = I>(
@@ -58,6 +59,7 @@ export function scan<I, A = I>(
  * ```ts
  * import { scan } from "@milly/streams/transform/scan";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(scan(
@@ -65,7 +67,7 @@ export function scan<I, A = I>(
  *   10
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [11, 13, 16]
+ * assertEquals(result, [11, 13, 16]);
  * ```
  */
 export function scan<I, A, V = A>(

--- a/transform/skip.ts
+++ b/transform/skip.ts
@@ -15,11 +15,12 @@
  * ```ts
  * import { skip } from "@milly/streams/transform/skip";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 4, 5]);
  * const output = source.pipeThrough(skip(3));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [4, 5]
+ * assertEquals(result, [4, 5]);
  * ```
  */
 export function skip<T>(count = 1): TransformStream<T, T> {

--- a/transform/skip_last.ts
+++ b/transform/skip_last.ts
@@ -15,11 +15,12 @@
  * ```ts
  * import { skipLast } from "@milly/streams/transform/skip-last";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 4, 5]);
  * const output = source.pipeThrough(skipLast(2));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 2, 3]
+ * assertEquals(result, [1, 2, 3]);
  * ```
  */
 export function skipLast<T>(count = 1): TransformStream<T, T> {

--- a/transform/skip_while.ts
+++ b/transform/skip_while.ts
@@ -19,11 +19,12 @@ import type { Falsy } from "../internal/types.ts";
  * ```ts
  * import { skipWhile } from "@milly/streams/transform/skip-while";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 0, 3, 4]);
  * const output = source.pipeThrough(skipWhile(Boolean));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 3, 4]
+ * assertEquals(result, [0, 3, 4]);
  * ```
  */
 export function skipWhile<T>(
@@ -41,11 +42,12 @@ export function skipWhile<T>(
  * ```ts
  * import { skipWhile } from "@milly/streams/transform/skip-while";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 2, 0]);
  * const output = source.pipeThrough(skipWhile((value) => value <= 2));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [3, 2, 0]
+ * assertEquals(result, [3, 2, 0]);
  * ```
  */
 export function skipWhile<T>(predicate: PredicateFn<T>): TransformStream<T, T>;

--- a/transform/switch_all.ts
+++ b/transform/switch_all.ts
@@ -23,6 +23,7 @@ import { switchMap } from "./switch_map.ts";
  * import { map } from "@milly/streams/transform/map";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // source:timer  : 0 -300ms------> 1 -300ms------> 2 |
  * // source:map[0] : 0 -200ms-> 0 -200ms-> 0 |
@@ -40,7 +41,7 @@ import { switchMap } from "./switch_map.ts";
  * ));
  * const output = source.pipeThrough(switchAll());
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 0, 1, 1, 2, 2, 2]
+ * assertEquals(result, [0, 0, 1, 1, 2, 2, 2]);
  * ```
  */
 export function switchAll<T>(): TransformStream<StreamSource<T>, T> {

--- a/transform/switch_map.ts
+++ b/transform/switch_map.ts
@@ -26,6 +26,7 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  * import { map } from "@milly/streams/transform/map";
  * import { pipe } from "@milly/streams/transform/pipe";
  * import { take } from "@milly/streams/transform/take";
+ * import { assertEquals } from "@std/assert";
  *
  * // source     : 0 -300ms------> 1 -300ms------> 2 |
  * // project[0] : 0 -200ms-> 0 -> |
@@ -40,7 +41,7 @@ import { toReadableStream } from "../internal/to_readable_stream.ts";
  *   ))
  * ));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [0, 0, 1, 1, 2, 2, 2]
+ * assertEquals(result, [0, 0, 1, 1, 2, 2, 2]);
  * ```
  */
 export function switchMap<I, O>(

--- a/transform/take.ts
+++ b/transform/take.ts
@@ -18,11 +18,12 @@ import { terminate } from "./terminate.ts";
  * ```ts
  * import { take } from "@milly/streams/transform/take";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 4, 5]);
  * const output = source.pipeThrough(take(2));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 2]
+ * assertEquals(result, [1, 2]);
  * ```
  */
 export function take<T>(count = 1): TransformStream<T, T> {

--- a/transform/take_last.ts
+++ b/transform/take_last.ts
@@ -18,11 +18,12 @@ import { terminate } from "./terminate.ts";
  * ```ts
  * import { takeLast } from "@milly/streams/transform/take-last";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 4, 5]);
  * const output = source.pipeThrough(takeLast(2));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [4, 5]
+ * assertEquals(result, [4, 5]);
  * ```
  */
 export function takeLast<T>(count = 1): TransformStream<T, T> {

--- a/transform/take_while.ts
+++ b/transform/take_while.ts
@@ -33,13 +33,14 @@ export interface TakeWhileOptions {
  * ```ts
  * import { takeWhile } from "@milly/streams/transform/take-while";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from(["a", "b", 1, 2, "c", 3]);
  * const output = source.pipeThrough(
  *   takeWhile((value: unknown): value is string => typeof value === "string"),
  * );
  * const result = await Array.fromAsync(output);
- * console.log(result); // ["a", "b"]
+ * assertEquals(result, ["a", "b"]);
  * ```
  */
 export function takeWhile<I, O extends I>(
@@ -58,11 +59,12 @@ export function takeWhile<I, O extends I>(
  * ```ts
  * import { takeWhile } from "@milly/streams/transform/take-while";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 0, 3, 4]);
  * const output = source.pipeThrough(takeWhile(Boolean));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 2]
+ * assertEquals(result, [1, 2]);
  * ```
  */
 export function takeWhile<T>(
@@ -82,11 +84,12 @@ export function takeWhile<T>(
  * ```ts
  * import { takeWhile } from "@milly/streams/transform/take-while";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3, 2, 0]);
  * const output = source.pipeThrough(takeWhile((value) => value <= 2));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [1, 2]
+ * assertEquals(result, [1, 2]);
  * ```
  */
 export function takeWhile<T>(

--- a/transform/tap.ts
+++ b/transform/tap.ts
@@ -93,17 +93,17 @@ export interface TapController {
  * import { from } from "@milly/streams/readable/from";
  * import { map } from "@milly/streams/transform/map";
  * import { pipe } from "@milly/streams/transform/pipe";
+ * import { assertEquals } from "@std/assert";
  *
+ * const log: unknown[] = [];
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(pipe(
- *   tap((value) => console.log(value)), // It has no effect on stream.
+ *   tap((value) => log.push(value)), // It has no effect on stream.
  *   map((value) => value * 2),
  * ));
  * const result = await Array.fromAsync(output);
- * // 1
- * // 2
- * // 3
- * console.log(result); // [2, 4, 6]
+ * assertEquals(log, [1, 2, 3]);
+ * assertEquals(result, [2, 4, 6]);
  * ```
  */
 export function tap<T>(

--- a/transform/tap_test.ts
+++ b/transform/tap_test.ts
@@ -12,7 +12,7 @@ describe("tap()", () => {
       it("emits the source chunk type", () => {
         const source = new ReadableStream<number>();
 
-        const output = source.pipeThrough(tap((value) => console.log(value)));
+        const output = source.pipeThrough(tap((_value): void => {}));
 
         assertType<IsExact<typeof output, ReadableStream<number>>>(true);
       });

--- a/transform/terminate.ts
+++ b/transform/terminate.ts
@@ -12,11 +12,12 @@
  * ```ts
  * import { terminate } from "@milly/streams/transform/terminate";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const source = from([1, 2, 3]);
  * const output = source.pipeThrough(terminate());
  * const result = await Array.fromAsync(output);
- * console.log(result); // []
+ * assertEquals(result, []);
  * ```
  */
 export function terminate(): TransformStream<unknown, never> {

--- a/transform/transform.ts
+++ b/transform/transform.ts
@@ -26,6 +26,7 @@ const NOOP = () => {};
  * ```ts
  * import { transform } from "@milly/streams/transform/transform";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const output = from([1, 2, 3])
  *   .pipeThrough(transform(async function* (source) {
@@ -34,7 +35,7 @@ const NOOP = () => {};
  *     }
  *   }));
  * const result = await Array.fromAsync(output);
- * console.log(result); // [10, 20, 30]
+ * assertEquals(result, [10, 20, 30]);
  * ```
  */
 export function transform<I, O>(

--- a/util/pull.ts
+++ b/util/pull.ts
@@ -17,13 +17,14 @@
  * ```ts
  * import { pull } from "@milly/streams/util/pull";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = from([1, 2, 3]);
  *
- * console.log(await pull(stream)); // 1
- * console.log(await pull(stream)); // 2
- * console.log(await pull(stream)); // 3
- * console.log(await pull(stream)); // undefined
+ * assertEquals(await pull(stream), 1);
+ * assertEquals(await pull(stream), 2);
+ * assertEquals(await pull(stream), 3);
+ * assertEquals(await pull(stream), undefined);
  * ```
  */
 export async function pull<T, D>(

--- a/util/to_array.ts
+++ b/util/to_array.ts
@@ -30,10 +30,11 @@ import { getIterator, iteratorNext } from "../internal/iterator.ts";
  * ```ts
  * import { toArray } from "@milly/streams/util/to-array";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
  *
  * const stream = from([1, 2, 3]);
- * const array = toArray(stream);
- * console.log(array); // [1, 2, 3]
+ * const array = await toArray(stream);
+ * assertEquals(array, [1, 2, 3]);
  * ```
  */
 export async function toArray<T, R>(

--- a/util/write.ts
+++ b/util/write.ts
@@ -17,18 +17,18 @@
  * @example
  * ```ts
  * import { write } from "@milly/streams/util/write";
+ * import { assertEquals } from "@std/assert";
  *
- * const results: number[] = [];
+ * const result: number[] = [];
  * const stream = new WritableStream<number>({
  *   write(chunk) {
- *     results.push(chunk);
+ *     result.push(chunk);
  *   },
  * });
- *
  * await write(stream, 1);
  * await write(stream, 2, 3);
  * await write(stream, Promise.resolve(4));
- * console.log(results); // [1, 2, 3, 4]
+ * assertEquals(result, [1, 2, 3, 4]);
  * ```
  */
 export async function write<T>(

--- a/writable/for_each.ts
+++ b/writable/for_each.ts
@@ -14,14 +14,20 @@ import type { WriteFn } from "../types.ts";
  * ```ts
  * import { forEach } from "@milly/streams/writable/for-each";
  * import { from } from "@milly/streams/readable/from";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const result: unknown[] = [];
  *
  * await from([1, "foo", true])
  *   .pipeTo(forEach((chunk, index) => {
- *     console.log([chunk, index]);
+ *     result.push([chunk, index]);
  *   }));
- * // output: [1, 0]
- * // output: ["foo", 1]
- * // output: [true, 2]
+ *
+ * assertEquals(result, [
+ *   [1, 0],
+ *   ["foo", 1],
+ *   [true, 2],
+ * ]);
  * ```
  *
  * @template T The chunk type.

--- a/writable/post_message.ts
+++ b/writable/post_message.ts
@@ -41,6 +41,7 @@ export interface PostMessageOptions<T> {
  * import { postMessage } from "@milly/streams/writable/post-message";
  * import { from } from "@milly/streams/readable/from";
  * import { delay } from "@std/async/delay";
+ * import { assertEquals } from "@std/assert";
  *
  * const { port1, port2 } = new MessageChannel();
  * const result: unknown[] = [];
@@ -50,7 +51,7 @@ export interface PostMessageOptions<T> {
  * await from([1, "foo", true]).pipeTo(postMessage(port1));
  * port1.close();
  * await delay(0); // onmessage will be called next tick.
- * console.log(result); // [1, "foo", true]
+ * assertEquals(result, [1, "foo", true]);
  * port2.close();
  * ```
  *
@@ -75,6 +76,7 @@ export function postMessage<T>(
  * import { postMessage } from "@milly/streams/writable/post-message";
  * import { from } from "@milly/streams/readable/from";
  * import { delay } from "@std/async/delay";
+ * import { assertEquals } from "@std/assert";
  *
  * const { port1, port2 } = new MessageChannel();
  * const result: unknown[] = [];
@@ -84,7 +86,7 @@ export function postMessage<T>(
  * await from([1, "foo", true]).pipeTo(postMessage(port1));
  * port1.close();
  * await delay(0); // onmessage will be called next tick.
- * console.log(result); // [1, "foo", true]
+ * assertEquals(result, [1, "foo", true]);
  * port2.close();
  * ```
  *


### PR DESCRIPTION
Replace console.log statements with assertEquals/assertRejects in documentation examples. These examples are executed as tests via deno task test:doc, ensuring they remain valid and functional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all example code in documentation to use programmatic assertions (`assertEquals`, `assertRejects`) instead of `console.log` statements for result verification.
  * Improved clarity and testability of examples across multiple functions by demonstrating explicit output checks.
  * Adjusted imports in examples to include assertion utilities where needed.
  * Minor formatting improvements in example code for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->